### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -11,4 +11,4 @@ sklearn
 numpy>=1.20
 pyopenjtalk==0.3.0
 pytorch-lightning==1.7.7
-evaluate==0.2.2
+evaluate==0.3.0


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.